### PR TITLE
Add a storybook log hook to avoid code duplication

### DIFF
--- a/src/hooks/useStorybookLog.ts
+++ b/src/hooks/useStorybookLog.ts
@@ -9,11 +9,9 @@ import type { Binding } from '@muban/muban/types/lib/bindings/bindings.types';
  *
  * @param logRef The Ref that will hold the logs.
  */
-export function useStorybookLog(logRef: ElementRef | ComponentRef<ComponentFactory>): {
-  logs: Array<string>;
-  log: (message: string) => void;
-  logBinding: Binding;
-} {
+export function useStorybookLog(
+  logRef: ElementRef | ComponentRef<ComponentFactory>,
+): readonly [(message: string) => void, Binding, Array<string>] {
   const logs = reactive<Array<string>>([]);
 
   function log(message: string): void {
@@ -23,15 +21,15 @@ export function useStorybookLog(logRef: ElementRef | ComponentRef<ComponentFacto
     }, 2000);
   }
 
-  return {
-    logs,
+  return [
     log,
-    logBinding: bind(logRef, {
+    bind(logRef, {
       html: computed(() =>
         logs
           .map((value) => html`<div class="alert alert-dismissible alert-info">${value}</div>`)
           .join(''),
       ),
     }),
-  };
+    logs,
+  ];
 }

--- a/src/hooks/useStorybookLog.ts
+++ b/src/hooks/useStorybookLog.ts
@@ -7,12 +7,12 @@ import type { Binding } from '@muban/muban/types/lib/bindings/bindings.types';
 /**
  * This hook can be used to keep track of logs within Storybook
  *
- * @param ref The Ref that will hold the logs.
+ * @param logRef The Ref that will hold the logs.
  */
-export function useStorybookLog(ref: ElementRef | ComponentRef<ComponentFactory>): {
+export function useStorybookLog(logRef: ElementRef | ComponentRef<ComponentFactory>): {
   logs: Array<string>;
   log: (message: string) => void;
-  binding: Binding;
+  logBinding: Binding;
 } {
   const logs = reactive<Array<string>>([]);
 
@@ -26,7 +26,7 @@ export function useStorybookLog(ref: ElementRef | ComponentRef<ComponentFactory>
   return {
     logs,
     log,
-    binding: bind(ref, {
+    logBinding: bind(logRef, {
       html: computed(() =>
         logs
           .map((value) => html`<div class="alert alert-dismissible alert-info">${value}</div>`)

--- a/src/hooks/useStorybookLog.ts
+++ b/src/hooks/useStorybookLog.ts
@@ -1,19 +1,37 @@
-import { reactive } from '@muban/muban';
+/* eslint-disable import/no-extraneous-dependencies */
+import type { ComponentRef, ElementRef, ComponentFactory } from '@muban/muban';
+import { html } from '@muban/template';
+import { bind, computed, reactive } from '@muban/muban';
+import type { Binding } from '@muban/muban/types/lib/bindings/bindings.types';
 
 /**
  * This hook can be used to keep track of logs within Storybook
  *
- * @returns
+ * @param ref The Ref that will hold the logs.
  */
-export function useStorybookLog(): { state: Array<string>; log: (message: string) => void } {
-  const state = reactive<Array<string>>([]);
+export function useStorybookLog(ref: ElementRef | ComponentRef<ComponentFactory>): {
+  logs: Array<string>;
+  log: (message: string) => void;
+  binding: Binding;
+} {
+  const logs = reactive<Array<string>>([]);
 
   function log(message: string): void {
-    state.push(message);
+    logs.push(message);
     setTimeout(() => {
-      state.splice(0, 1);
+      logs.splice(0, 1);
     }, 2000);
   }
 
-  return { state, log };
+  return {
+    logs,
+    log,
+    binding: bind(ref, {
+      html: computed(() =>
+        logs
+          .map((value) => html`<div class="alert alert-dismissible alert-info">${value}</div>`)
+          .join(''),
+      ),
+    }),
+  };
 }

--- a/src/hooks/useStorybookLog.ts
+++ b/src/hooks/useStorybookLog.ts
@@ -11,7 +11,7 @@ import type { Binding } from '@muban/muban/types/lib/bindings/bindings.types';
  */
 export function useStorybookLog(
   logRef: ElementRef | ComponentRef<ComponentFactory>,
-): readonly [(message: string) => void, Binding, Array<string>] {
+): readonly [Binding, (message: string) => void] {
   const logs = reactive<Array<string>>([]);
 
   function log(message: string): void {
@@ -22,14 +22,13 @@ export function useStorybookLog(
   }
 
   return [
-    log,
     bind(logRef, {
       html: computed(() =>
         logs
-          .map((value) => html`<div class="alert alert-dismissible alert-info">${value}</div>`)
+          .map((value) => html` <div class="alert alert-dismissible alert-info">${value}</div>`)
           .join(''),
       ),
     }),
-    logs,
+    log,
   ];
 }

--- a/src/hooks/useStorybookLog.ts
+++ b/src/hooks/useStorybookLog.ts
@@ -1,0 +1,19 @@
+import { reactive } from '@muban/muban';
+
+/**
+ * This hook can be used to keep track of logs within Storybook
+ *
+ * @returns
+ */
+export function useStorybookLog(): { state: Array<string>; log: (message: string) => void } {
+  const state = reactive<Array<string>>([]);
+
+  function log(message: string): void {
+    state.push(message);
+    setTimeout(() => {
+      state.splice(0, 1);
+    }, 2000);
+  }
+
+  return { state, log };
+}

--- a/src/useClickedOutside/useClickedOutside.stories.ts
+++ b/src/useClickedOutside/useClickedOutside.stories.ts
@@ -18,7 +18,7 @@ export const Demo: Story = () => ({
       label: 'label',
     },
     setup({ refs }) {
-      const { log, logBinding } = useStorybookLog(refs.label);
+      const [log, logBinding] = useStorybookLog(refs.label);
 
       useClickedOutside(refs.testArea, () => {
         log('clicked outside the test area');
@@ -27,7 +27,7 @@ export const Demo: Story = () => ({
       return [logBinding];
     },
   }),
-  template: () => html` <div data-component="story" data-initial-value="true">
+  template: () => html`<div data-component="story" data-initial-value="true">
     <div class="alert alert-primary">
       <h4 class="alert-heading">Instructions!</h4>
       <p class="mb-0">Click outside the <code>"Test Area"</code> to see events being triggered</p>

--- a/src/useClickedOutside/useClickedOutside.stories.ts
+++ b/src/useClickedOutside/useClickedOutside.stories.ts
@@ -1,9 +1,10 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
-import { bind, computed, defineComponent, reactive } from '@muban/muban';
+import { defineComponent } from '@muban/muban';
 import type { Story } from '@muban/storybook/types-6-0';
 import { html } from '@muban/template';
 import { useClickedOutside } from './useClickedOutside';
+import { useStorybookLog } from '../hooks/useStorybookLog';
 
 export default {
   title: 'useClickedOutside',
@@ -17,30 +18,13 @@ export const Demo: Story = () => ({
       label: 'label',
     },
     setup({ refs }) {
-      const state = reactive<Array<string>>([]);
-
-      const log = (message: string) => {
-        state.push(message);
-        setTimeout(() => {
-          state.splice(0, 1);
-        }, 2000);
-      };
+      const { log, logBinding } = useStorybookLog(refs.label);
 
       useClickedOutside(refs.testArea, () => {
         log('clicked outside the test area');
       });
 
-      return [
-        bind(refs.label, {
-          html: computed(() =>
-            state
-              .map(
-                (message) => html`<div class="alert alert-dismissible alert-info">${message}</div>`,
-              )
-              .join(''),
-          ),
-        }),
-      ];
+      return [logBinding];
     },
   }),
   template: () => html` <div data-component="story" data-initial-value="true">

--- a/src/useClickedOutside/useClickedOutside.stories.ts
+++ b/src/useClickedOutside/useClickedOutside.stories.ts
@@ -18,7 +18,7 @@ export const Demo: Story = () => ({
       label: 'label',
     },
     setup({ refs }) {
-      const [log, logBinding] = useStorybookLog(refs.label);
+      const [logBinding, log] = useStorybookLog(refs.label);
 
       useClickedOutside(refs.testArea, () => {
         log('clicked outside the test area');

--- a/src/useEventListener/useEventListener.stories.ts
+++ b/src/useEventListener/useEventListener.stories.ts
@@ -25,7 +25,7 @@ export const Demo: Story = () => ({
       component: refComponent(Test),
     },
     setup({ refs }) {
-      const [log, logBinding] = useStorybookLog(refs.label);
+      const [logBinding, log] = useStorybookLog(refs.label);
 
       useEventListener(window, 'click', () => {
         log('clicked the window');

--- a/src/useEventListener/useEventListener.stories.ts
+++ b/src/useEventListener/useEventListener.stories.ts
@@ -1,10 +1,9 @@
-/* eslint-disable unicorn/prevent-abbreviations,import/no-extraneous-dependencies */
-// import UseToggleDocs from './useEventListener.docs.mdx';
-
-import { bind, computed, defineComponent, reactive, refComponent } from '@muban/muban';
+/* eslint-disable import/no-extraneous-dependencies */
+import { bind, computed, defineComponent, refComponent } from '@muban/muban';
 import type { Story } from '@muban/storybook/types-6-0';
 import { html } from '@muban/template';
 import { useEventListener } from './useEventListener';
+import { useStorybookLog } from '../hooks/useStorybookLog';
 
 export default {
   title: 'useEventListener',
@@ -26,14 +25,7 @@ export const Demo: Story = () => ({
       component: refComponent(Test),
     },
     setup({ refs }) {
-      const state = reactive<Array<string>>([]);
-
-      const log = (message: string) => {
-        state.push(message);
-        setTimeout(() => {
-          state.splice(0, 1);
-        }, 2000);
-      };
+      const { state, log } = useStorybookLog();
 
       useEventListener(window, 'click', () => {
         log('clicked the window');
@@ -52,7 +44,7 @@ export const Demo: Story = () => ({
         bind(refs.label, {
           html: computed(() =>
             state
-              .map((msg) => html`<div class="alert alert-dismissible alert-info">${msg}</div>`)
+              .map((value) => html`<div class="alert alert-dismissible alert-info">${value}</div>`)
               .join(''),
           ),
         }),

--- a/src/useEventListener/useEventListener.stories.ts
+++ b/src/useEventListener/useEventListener.stories.ts
@@ -1,5 +1,5 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { bind, computed, defineComponent, refComponent } from '@muban/muban';
+import { defineComponent, refComponent } from '@muban/muban';
 import type { Story } from '@muban/storybook/types-6-0';
 import { html } from '@muban/template';
 import { useEventListener } from './useEventListener';
@@ -25,7 +25,7 @@ export const Demo: Story = () => ({
       component: refComponent(Test),
     },
     setup({ refs }) {
-      const { state, log } = useStorybookLog();
+      const { log, binding } = useStorybookLog(refs.label);
 
       useEventListener(window, 'click', () => {
         log('clicked the window');
@@ -40,15 +40,7 @@ export const Demo: Story = () => ({
         log('clicked the component');
       });
 
-      return [
-        bind(refs.label, {
-          html: computed(() =>
-            state
-              .map((value) => html`<div class="alert alert-dismissible alert-info">${value}</div>`)
-              .join(''),
-          ),
-        }),
-      ];
+      return [binding];
     },
   }),
   template: () => html`<div data-component="story" data-initial-value="true">

--- a/src/useEventListener/useEventListener.stories.ts
+++ b/src/useEventListener/useEventListener.stories.ts
@@ -25,7 +25,7 @@ export const Demo: Story = () => ({
       component: refComponent(Test),
     },
     setup({ refs }) {
-      const { log, logBinding } = useStorybookLog(refs.label);
+      const [log, logBinding] = useStorybookLog(refs.label);
 
       useEventListener(window, 'click', () => {
         log('clicked the window');

--- a/src/useEventListener/useEventListener.stories.ts
+++ b/src/useEventListener/useEventListener.stories.ts
@@ -25,7 +25,7 @@ export const Demo: Story = () => ({
       component: refComponent(Test),
     },
     setup({ refs }) {
-      const { log, binding } = useStorybookLog(refs.label);
+      const { log, logBinding } = useStorybookLog(refs.label);
 
       useEventListener(window, 'click', () => {
         log('clicked the window');
@@ -40,7 +40,7 @@ export const Demo: Story = () => ({
         log('clicked the component');
       });
 
-      return [binding];
+      return [logBinding];
     },
   }),
   template: () => html`<div data-component="story" data-initial-value="true">

--- a/src/useToggle/useToggle.ts
+++ b/src/useToggle/useToggle.ts
@@ -1,4 +1,5 @@
-import { isRef, ref, Ref, unref, watchEffect } from '@muban/muban';
+import type { Ref } from '@muban/muban';
+import { isRef, ref, unref, watchEffect } from '@muban/muban';
 
 /**
  * Easily toggle value between two states


### PR DESCRIPTION
I've noticed that on other PR's we use this `log` functionality a lot, this PR will add a local hook that we can use instead of re-typing it over and over again.